### PR TITLE
README.md event turbolinks:load

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In application.js:
 //= require flatpickr
 //= require flatpickr/plugins/confirmDate/confirmDate
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('turbolinks:load', function() {
   flatpickr('.your-selector', {
     enableTime: true,
     plugins: [


### PR DESCRIPTION
changed the event in application.js on markdown file for quick setup. It's more suited for a library that is not aware of turbolinks in Rails.